### PR TITLE
Fix: pass options to `token_headers`

### DIFF
--- a/lib/doorkeeper-jwt.rb
+++ b/lib/doorkeeper-jwt.rb
@@ -10,7 +10,7 @@ module Doorkeeper
           token_payload(opts),
           secret_key(opts),
           encryption_method,
-          token_headers
+          token_headers(opts)
         )
       end
 


### PR DESCRIPTION
Pass `opts` to `token_headers` so we can use it in our configuration block